### PR TITLE
Remove lodash.isequal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-select",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A keyboard accessible React responsive select and multiselect form control",
   "main": "dist/ReactResponsiveSelect.js",
   "scripts": {
@@ -70,8 +70,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "singleline": "1.0.x",
-    "lodash.isequal": "4.5.x"
+    "singleline": "1.0.x"
   },
   "devDependencies": {
     "babel-core": "6.25.x",

--- a/src/lib/simpleArraysEqual.js
+++ b/src/lib/simpleArraysEqual.js
@@ -1,0 +1,18 @@
+/**
+* A function to shallow compare 2 arrays. Does not work on an
+* array of objects or an array of arrays
+* @param {Array} a - shallow array
+* @param {Array} b - shallow array
+* @returns {Boolean}
+*/
+export default function simpleArraysEqual(a, b) {
+  const aLength = a.length;
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (aLength !== b.length) return false;
+
+  for (let i = 0; i < aLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/src/lib/simpleArraysEqual__test__.js
+++ b/src/lib/simpleArraysEqual__test__.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import simpleArraysEqual from './simpleArraysEqual';
+
+describe('simpleArraysEqual', () => {
+
+  it('should determine whether an array of numbers has changed', () => {
+    const arrayA = [1,2,3];
+    const arrayB = [1,2];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(false);
+  });
+
+  it('should determine whether an array of strings has changed', () => {
+    const arrayA = ['a','b','c'];
+    const arrayB = ['a','b','c','d'];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(false);
+  });
+
+  it('should determine whether an array of booleans has changed', () => {
+    const arrayA = [true,true,false];
+    const arrayB = [true,true,false,true];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(false);
+  });
+
+  it('should determine whether an array of strings is the same', () => {
+    const arrayA = ['a','b','c'];
+    const arrayB = ['a','b','c'];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(true);
+  });
+
+  it('should determine whether an array of numbers is the same', () => {
+    const arrayA = [1,2,3];
+    const arrayB = [1,2,3];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(true);
+  });
+
+  it('should determine whether an array of booleans is the same', () => {
+    const arrayA = [true,true,false,true];
+    const arrayB = [true,true,false,true];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(true);
+  });
+
+  it('should determine whether a mixed array of strings, numbers and booleans is the same', () => {
+    const arrayA = [true,true,false,true,1,5,'seven'];
+    const arrayB = [true,true,false,true,1,5,'seven'];
+
+    expect(simpleArraysEqual(arrayA, arrayB)).to.equal(true);
+  });
+});

--- a/src/reducers/lib/mergeIsAlteredState.js
+++ b/src/reducers/lib/mergeIsAlteredState.js
@@ -1,9 +1,9 @@
-import _isEqual from 'lodash.isequal';
+import simpleArraysEqual from '../../lib/simpleArraysEqual';
 
 export function isAltered(newState) {
   return (!newState.isMultiSelect)
     ? newState.singleSelectSelectedIndex !== newState.singleSelectInitialIndex
-    : !_isEqual(newState.multiSelectInitialSelectedIndexes, newState.multiSelectSelectedIndexes);
+    : !simpleArraysEqual(newState.multiSelectInitialSelectedIndexes, newState.multiSelectSelectedIndexes);
 }
 
 export default function mergeIsAlteredState(newState) {


### PR DESCRIPTION
- [x] Remove `lodash.isequal` dependency, because the comparison is currently simple enough not to require it.

<img src="https://media0.giphy.com/media/YqGeOQ0u6hB5u/giphy.gif?fingerprint=e1bb72ff59812ee34135563349de62f2" width="100%" />