### PR TITLE
Fix scrollbar bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-select",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A React customisable, touchable, single-select / multi-select form component. Built with keyboard and screen reader accessibility in mind.",
   "main": "dist/ReactResponsiveSelect.js",
   "scripts": {

--- a/src/ReactResponsiveSelect.js
+++ b/src/ReactResponsiveSelect.js
@@ -251,7 +251,7 @@ export default class ReactResponsiveSelect extends Component {
       e.preventDefault();
 
       /* If user is scrolling return */
-      if (e && e.target.classList.contains('rrs__options-container')) {
+      if (e && e.target.classList.contains('rrs__options')) {
         return true;
       }
 


### PR DESCRIPTION
Clicking on the scrollbar on an options panel would close the options panel. Making scrolling via the scrollbar impossible. This bug would have existed since V3 of react-responsive-select - when updating of the class names occurred.

<img src="https://media1.giphy.com/media/26uSEsIogiTub9qSs/giphy.gif?fingerprint=e1bb72ff59e9a52c30333741325cb3b5" width="100%" />