### PR TITLE
Server side rendering bug caused by window object lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-select",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A React customisable, touchable, single-select / multi-select form component. Built with keyboard and screen reader accessibility in mind.",
   "main": "dist/ReactResponsiveSelect.js",
   "scripts": {

--- a/webpack.config.react-responsive-select.js
+++ b/webpack.config.react-responsive-select.js
@@ -21,7 +21,7 @@ module.exports = [{
   module: moduleConfig,
   output: {
     filename: 'ReactResponsiveSelect.js',
-    libraryTarget: 'umd',
+    libraryTarget: 'commonjs2',
     library,
   },
   externals: [nodeExternals({ whitelist: ['prop-types'] })],


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/TlK63EJsc8ZiXeuYWNW/giphy.gif?cid=e1bb72ff5b0e9df24876733341e1457f" width="100%" />

Convert Webpack config output.libraryTarget from `umd` to `commonjs2` to fix window object bug in server-side-rendering https://github.com/benbowes/react-responsive-select/issues/72