### PR TITLE
`noSelectionLabel` blur fix for single select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-select",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "A React customisable, touchable, single-select / multi-select form component. Built with keyboard and screen reader accessibility in mind.",
   "main": "dist/ReactResponsiveSelect.js",
   "scripts": {

--- a/src/components/SingleSelect.js
+++ b/src/components/SingleSelect.js
@@ -17,6 +17,10 @@ export default class SingleSelect extends Component {
     ) {
       this.optionsButton.focus();
     }
+
+    if (this.props.nextPotentialSelectionIndex === -1) {
+      this.optionsButton.focus();
+    }
   }
 
   getCustomLabel() {


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/13sbWMa0NGNq2A/giphy.gif?cid=e1bb72ff5b7bb88252494b5463448bcc" width="100%" />

The new feature of allowing a custom empty message via `noSelectionLabel` did not close on click-outside - fix it by focussing button when no reasonable option exists. So that the onBlur script will find a previous element that resides within the select instance.