### PR TITLE
Use set options panel closed no selection when click on button

### DIFF
--- a/dist/ReactResponsiveSelect.css
+++ b/dist/ReactResponsiveSelect.css
@@ -48,7 +48,8 @@
   border-top: 1px solid #eee;
   border-radius: 0 0 2px 2px;
   top: 44px;
-  width: 100%;
+  left: 0;
+  right: 0;
   height: 0;
   visibility: hidden;
   overflow: hidden;
@@ -165,6 +166,10 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.rrs__label * {
+  pointer-events: none;
 }
 
 .rrs--options-visible .rrs__label,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-select",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "A React customisable, touchable, single-select / multi-select form component. Built with keyboard and screen reader accessibility in mind.",
   "main": "dist/ReactResponsiveSelect.js",
   "scripts": {

--- a/src/lib/eventHandlers/handleClick.js
+++ b/src/lib/eventHandlers/handleClick.js
@@ -46,6 +46,16 @@ export default function handleClick({
       return;
     }
 
+    // When the options panel is open, treat clicking the label/select button as a 'no action'
+    if (isOptionsPanelOpen && containsClassName(event.target, 'rrs__label')) {
+      ReactResponsiveSelectClassRef.updateState(
+        { type: actionTypes.SET_OPTIONS_PANEL_CLOSED_NO_SELECTION },
+        () => ReactResponsiveSelectClassRef.focusButton(),
+      );
+
+      return;
+    }
+
     /* Else user clicked close or open the options panel */
     ReactResponsiveSelectClassRef.updateState(
       {

--- a/src/lib/eventHandlers/handleClick.js
+++ b/src/lib/eventHandlers/handleClick.js
@@ -47,13 +47,12 @@ export default function handleClick({
     }
 
     /*
-      When the options panel is open, treat clicking 
-      the label/select button or the background overlay on mobile
-      as a 'no action'
+      When the options panel is open, treat clicking the label/select button
+      or the background overlay on small screen as a 'no action'
     */
     if (
       isOptionsPanelOpen &&
-      // button on desktop (rrs__label) or overlay on mobile (rrs)
+      // button on desktop (rrs__label) or overlay on small screen (rrs)
       (containsClassName(event.target, 'rrs__label') ||
         containsClassName(event.target, 'rrs'))
     ) {

--- a/src/lib/eventHandlers/handleClick.js
+++ b/src/lib/eventHandlers/handleClick.js
@@ -47,7 +47,12 @@ export default function handleClick({
     }
 
     // When the options panel is open, treat clicking the label/select button as a 'no action'
-    if (isOptionsPanelOpen && containsClassName(event.target, 'rrs__label')) {
+    if (
+      isOptionsPanelOpen &&
+      // button on desktop (rrs__label) or overlay on mobile (rrs)
+      (containsClassName(event.target, 'rrs__label') ||
+        containsClassName(event.target, 'rrs'))
+    ) {
       ReactResponsiveSelectClassRef.updateState(
         { type: actionTypes.SET_OPTIONS_PANEL_CLOSED_NO_SELECTION },
         () => ReactResponsiveSelectClassRef.focusButton(),

--- a/src/lib/eventHandlers/handleClick.js
+++ b/src/lib/eventHandlers/handleClick.js
@@ -46,7 +46,11 @@ export default function handleClick({
       return;
     }
 
-    // When the options panel is open, treat clicking the label/select button as a 'no action'
+    /*
+      When the options panel is open, treat clicking 
+      the label/select button or the background overlay on mobile
+      as a 'no action'
+    */
     if (
       isOptionsPanelOpen &&
       // button on desktop (rrs__label) or overlay on mobile (rrs)


### PR DESCRIPTION
- Use SET_OPTIONS_PANEL_CLOSED_NO_SELECTION when a user clicks the select button - assume they are making no choice
- Fix overflow-x problem (.rrs__options) in default ReactResponsiveSelect.css that was making the demo page add extra x width - use `left:0` and `right:0` instead of `width:100%`